### PR TITLE
Make airtable embed load at runtime instead of compile time

### DIFF
--- a/src/pages/register/index.js
+++ b/src/pages/register/index.js
@@ -1,28 +1,34 @@
-import React from 'react'
+import React, {useState, useEffect} from 'react'
 import Layout from '../../components/Layout'
 import useCanonicalLinkMetaTag from '../../components/useCanonicalLinkMetaTag'
 
 const Index = () => {
   const canonicalLinkMetaTag = useCanonicalLinkMetaTag('/register/')
+  const [airTable, setAirTable] = useState(null)
+  useEffect(() => {
+      setAirTable(
+        <iframe
+          class="airtable-embed airtable-dynamic-height"
+          src="https://airtable.com/embed/shrzIhb1Ih1XqNalH?backgroundColor=blue"
+          frameborder="0"
+          onmousewheel=""
+          width="100%"
+          height="4200px"
+          style={{
+            background: 'transparent',
+            border: '1px solid #ccc',
+          }}
+        ></iframe>
+      )
+  }, [])
+
   return (
     <Layout>
       {canonicalLinkMetaTag}
     <section className="section" style={{ height: '4500px' }}>
         <div className="container">
           <div className="content">
-            <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script>
-            <iframe
-              class="airtable-embed airtable-dynamic-height"
-              src="https://airtable.com/embed/shrzIhb1Ih1XqNalH?backgroundColor=blue"
-              frameborder="0"
-              onmousewheel=""
-              width="100%"
-              height="4200px"
-              style={{
-                background: 'transparent',
-                border: '1px solid #ccc',
-              }}
-            ></iframe>
+            {airTable}
           </div>
         </div>
       </section>


### PR DESCRIPTION
This seems to fix the problem with no scrollbar when entered text
content is long.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
Fix bug where airtable form doesn't add scrollbar when entered text content gets too long.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
None
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
