### PR TITLE
Fix bug with tabs bar appearing in front of main app bar on results page

### DIFF
--- a/src/components/ResultsPageContent.tsx
+++ b/src/components/ResultsPageContent.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react'
-import AppBar from '@material-ui/core/AppBar'
 import Tabs from '@material-ui/core/Tabs'
 import Tab from '@material-ui/core/Tab'
 import Typography from '@material-ui/core/Typography'
 import Box from '@material-ui/core/Box'
-
 import { Container } from '../components/materialUIContainers'
 import Release from '../components/Release'
 
@@ -49,13 +47,13 @@ const ResultsPageContent = ({ releases }: Props) => {
   }
 
   return (
-    <div>
-      <AppBar position="static">
+    <>
+      <Box bgcolor="primary.main" color="info.contrastText">
         <Tabs value={selectedRelease} onChange={handleChange} aria-label="simple tabs example">
           <Tab label="Release 3 (June 2020)" {...a11yProps(0)} />
           <Tab label="Release 2 (May 2020)" {...a11yProps(1)} />
         </Tabs>
-      </AppBar>
+      </Box>
       <Container marginTop={2} fixed={true}>
         <TabPanel value={selectedRelease} index={0}>
           <Release {...releases[0]} />
@@ -64,7 +62,7 @@ const ResultsPageContent = ({ releases }: Props) => {
           <Release {...releases[1]} />
         </TabPanel>
       </Container>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
- Fix bug where the tabs bar appearing in front of main app bar on results page when the page is scrolled in Firefox.

<img width="1051" alt="Screen Shot 2020-06-27 at 5 01 14 PM" src="https://user-images.githubusercontent.com/7352279/85932513-b33fd200-b89a-11ea-92ab-46c0e1a852ff.png">

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
None
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
