### PR TITLE
Create Meeting Archive “2022-12-16-december-14-2022-meeting”

### DIFF
--- a/src/components/LargeNavMenu.tsx
+++ b/src/components/LargeNavMenu.tsx
@@ -100,6 +100,7 @@ const navItems: NavItem[] = [
         label: 'Meeting Archive',
         icon: Notes,
         children: [
+          { href: '/blog/2022-12-16-december-14-2022-meeting/', label: 'December 15, 2022' },
           { href: '/blog/2022-02-07-february-1-2022-meeting/', label: 'February 1, 2022' },
           { href: '/blog/2021-09-27-september-20-2021-meeting/', label: 'September 20, 2021' },
           { href: '/blog/2021-06-17-june-14-2021-meeting/', label: 'June 14, 2021' },

--- a/src/pages/blog/2022-12-16-december-14-2022-meeting.md
+++ b/src/pages/blog/2022-12-16-december-14-2022-meeting.md
@@ -1,0 +1,29 @@
+---
+templateKey: blog-post
+title: December 14, 2022 meeting
+date: 2022-12-16T19:33:11.939Z
+tags:
+  - Archive
+type: meeting-notes
+---
+Webinar 14: December 15th, 2022 11:00am EST / 4:00pm GMT / 5:00pm CET
+
+## A﻿genda
+
+**1. Welcome**
+
+*Speaker*: Andrea Ganna, FIMM [[slides](https://docs.google.com/presentation/d/18XuNZ9XPQ_Zz4IOPw8X1PghREXkNb3sQ/edit?usp=sharing&ouid=115176384458245376274&rtpof=true&sd=true)]
+
+**2. Data Freeze 7 update**
+
+*Speaker*: Masahiro Kanai, The Broad Institute [[slides](https://drive.google.com/file/d/1ZxvJAw_3lReMl3IB_chz0Ng1CPOo8BSe/view?usp=sharing)]
+
+**3. Long COVID working group update**
+
+*Speaker*: Hanna Ollila, FIMM (with Vilma Lammi, FIMM, Samuel Jones, FIMM, and Tomoko Nakanishi, McGill) [[slides](https://docs.google.com/presentation/d/1ZBHS0wWxkNLFyKuUNminbeREJBd83Hnw/edit?usp=sharing&ouid=115176384458245376274&rtpof=true&sd=true)]
+
+**4. Open discussion**
+
+**Q&A**: [[here](https://docs.google.com/spreadsheets/d/1LdyojX_neFHQCIG3JJDDYGEb2wEoI7n1sHi0ouo94uk/edit?usp=sharing)]
+
+**Recording: [[here](https://drive.google.com/file/d/1eWAm68DeGK5xDQTnZ5QUe3J3MXu6BNDy/view?usp=sharing)]**

--- a/src/pages/blog/2022-12-16-december-14-2022-meeting.md
+++ b/src/pages/blog/2022-12-16-december-14-2022-meeting.md
@@ -1,6 +1,6 @@
 ---
 templateKey: blog-post
-title: December 14, 2022 meeting
+title: December 15, 2022 meeting
 date: 2022-12-16T19:33:11.939Z
 tags:
   - Archive


### PR DESCRIPTION
Some parts of the site, like the meetings archive, can be automatically generated by Netlify CMS.

How to do this: go to https://www.covid19hg.org/admin/#/collections/meeting-archive and add new entry that matches format of previous entries, then press save. This creates a new PR with the changes. Pressing "Publish" will merge, but we don't want that yet..

First, the navigation link has to be manually updated:

![image](https://user-images.githubusercontent.com/8867295/208178654-b3288a0b-40f6-494c-882c-a9ff7f0d87e4.png)

Pull this branch locally, and manually add it here https://github.com/covid19-hg/covid19hg/blob/365e3c720bc68ba26147233489afb1a1746382ae/src/components/LargeNavMenu.tsx#L103

Look at the build preview: https://app.netlify.com/teams/sponsored-covid19-account-7bcwhv8/builds

Merge PR when happy.


